### PR TITLE
fix(task): Allow resuming tasks in any non-completed state

### DIFF
--- a/server/task_manager.go
+++ b/server/task_manager.go
@@ -743,8 +743,8 @@ func (tm *DefaultTaskManager) ResumeTaskWithInput(taskID string, message *types.
 		return NewTaskNotFoundError(taskID)
 	}
 
-	if task.Status.State != types.TaskStateInputRequired {
-		return fmt.Errorf("task %s is not in input-required state, current state: %s", taskID, task.Status.State)
+	if task.Status.State == types.TaskStateCompleted {
+		return fmt.Errorf("task %s is already completed and cannot be resumed, current state: %s", taskID, task.Status.State)
 	}
 
 	timestamp := time.Now().UTC().Format(time.RFC3339Nano)


### PR DESCRIPTION
Fixes #50

This PR addresses the issue where task resumption was incorrectly restricted to only `input-required` state. Now any task that is not in `completed` state can be resumed, allowing recovery from connectivity issues or other interruptions.

## Changes
- Modified `ResumeTaskWithInput` to reject only completed tasks
- Updated tests to verify new behavior
- Added test for resuming completed tasks (should fail)

## Testing
- All existing tests pass
- Added comprehensive test coverage for the new behavior
- Linting passes with 0 issues

Generated with [Claude Code](https://claude.ai/code)