### PR TITLE
fix(streaming): Accumulate streaming deltas into single assistant message

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -988,12 +988,9 @@ func (s *A2AServerImpl) handleAgentStreaming(c *gin.Context, req types.JSONRPCRe
 		zap.String("task_id", task.ID),
 		zap.Int("total_messages", messageCount))
 
-	// Accumulate streaming deltas into a single assistant message
 	if len(allMessages) > 0 {
-		// Find the last non-chunk message or create a consolidated message
 		var consolidatedMessage *types.Message
 
-		// Look for the final assistant message (non-chunk)
 		for i := len(allMessages) - 1; i >= 0; i-- {
 			msg := &allMessages[i]
 			if msg.Role == "assistant" && !strings.HasPrefix(msg.MessageID, "chunk-") {
@@ -1002,7 +999,6 @@ func (s *A2AServerImpl) handleAgentStreaming(c *gin.Context, req types.JSONRPCRe
 			}
 		}
 
-		// If no consolidated message found, create one from chunks
 		if consolidatedMessage == nil {
 			var fullContent strings.Builder
 			var finalMessageID string
@@ -1016,11 +1012,10 @@ func (s *A2AServerImpl) handleAgentStreaming(c *gin.Context, req types.JSONRPCRe
 							}
 						}
 					}
-					finalMessageID = msg.MessageID // Keep track of the last chunk ID
+					finalMessageID = msg.MessageID
 				}
 			}
 
-			// Create consolidated message only if we have content
 			if fullContent.Len() > 0 {
 				consolidatedMessage = &types.Message{
 					Kind:      "message",
@@ -1036,7 +1031,6 @@ func (s *A2AServerImpl) handleAgentStreaming(c *gin.Context, req types.JSONRPCRe
 			}
 		}
 
-		// Add only the consolidated message to history
 		if consolidatedMessage != nil {
 			task.History = append(task.History, *consolidatedMessage)
 		}

--- a/server/server.go
+++ b/server/server.go
@@ -958,7 +958,6 @@ func (s *A2AServerImpl) handleAgentStreaming(c *gin.Context, req types.JSONRPCRe
 				zap.Int("message_count", messageCount),
 				zap.String("message_id", streamMessage.MessageID))
 
-			// Create status update for this streaming message
 			task.Status.State = types.TaskStateWorking
 			task.Status.Message = streamMessage
 

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -387,7 +387,6 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 		return task, nil
 	}
 
-	// Collect all streaming messages
 	var additionalMessages []types.Message
 	var lastMessage *types.Message
 
@@ -398,7 +397,6 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 		}
 	}
 
-	// Check for input required in the last message
 	if lastMessage != nil && lastMessage.Kind == "input_required" {
 		inputMessage := "Please provide more information to continue streaming."
 		if len(lastMessage.Parts) > 0 {

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -412,12 +412,10 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 		return sth.pauseTaskForStreamingInput(task, inputMessage), nil
 	}
 
-	// Accumulate streaming deltas into a single assistant message
 	if len(additionalMessages) > 0 {
 		// Find the last non-chunk message or create a consolidated message
 		var consolidatedMessage *types.Message
 
-		// Look for the final assistant message (non-chunk)
 		for i := len(additionalMessages) - 1; i >= 0; i-- {
 			msg := &additionalMessages[i]
 			if msg.Role == "assistant" && !strings.HasPrefix(msg.MessageID, "chunk-") {
@@ -426,7 +424,6 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 			}
 		}
 
-		// If no consolidated message found, create one from chunks
 		if consolidatedMessage == nil {
 			var fullContent strings.Builder
 			var finalMessageID string
@@ -440,11 +437,10 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 							}
 						}
 					}
-					finalMessageID = msg.MessageID // Keep track of the last chunk ID
+					finalMessageID = msg.MessageID
 				}
 			}
 
-			// Create consolidated message only if we have content
 			if fullContent.Len() > 0 {
 				consolidatedMessage = &types.Message{
 					Kind:      "message",
@@ -460,7 +456,6 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 			}
 		}
 
-		// Add only the consolidated message to history
 		if consolidatedMessage != nil {
 			task.History = append(task.History, *consolidatedMessage)
 		}

--- a/server/task_handler.go
+++ b/server/task_handler.go
@@ -413,7 +413,6 @@ func (sth *DefaultStreamingTaskHandler) processWithAgentStreaming(ctx context.Co
 	}
 
 	if len(additionalMessages) > 0 {
-		// Find the last non-chunk message or create a consolidated message
 		var consolidatedMessage *types.Message
 
 		for i := len(additionalMessages) - 1; i >= 0; i-- {


### PR DESCRIPTION
Fixes #52

## Problem
Streaming responses were storing each delta chunk (like `chunk-5-455`, `chunk-5-460`) as separate messages in conversation history instead of accumulating them into a single assistant message.

## Solution
- Modified `handleAgentStreaming` in server.go to consolidate streaming chunks
- Modified `DefaultStreamingTaskHandler` to use same consolidation logic
- Streaming responses now store as single assistant message instead of multiple chunk messages
- Added strings import to server.go for string processing functions

## Testing
- ✅ All existing tests pass
- ✅ No linting issues
- ✅ Code formatting applied
- ✅ Logic tested with mock streaming data

Generated with [Claude Code](https://claude.ai/code)