### PR TITLE
fix(agent): Fix NewAgentBuilder.WithConfig to preserve user configuration values

### DIFF
--- a/server/agent_builder.go
+++ b/server/agent_builder.go
@@ -94,14 +94,9 @@ func NewAgentBuilder(logger *zap.Logger) AgentBuilder {
 // WithConfig sets the agent configuration
 func (b *AgentBuilderImpl) WithConfig(userConfig *config.AgentConfig) AgentBuilder {
 	if userConfig != nil {
-		tempConfig := &config.Config{AgentConfig: *userConfig}
-
-		mergedConfig, err := config.NewWithDefaults(context.Background(), tempConfig)
-		if err == nil && mergedConfig != nil {
-			b.config = &mergedConfig.AgentConfig
-		} else {
-			b.config = userConfig
-		}
+		// Directly use the user's config without processing through defaults
+		// since the user has already provided their desired configuration values
+		b.config = userConfig
 	}
 	return b
 }

--- a/server/agent_builder.go
+++ b/server/agent_builder.go
@@ -94,8 +94,6 @@ func NewAgentBuilder(logger *zap.Logger) AgentBuilder {
 // WithConfig sets the agent configuration
 func (b *AgentBuilderImpl) WithConfig(userConfig *config.AgentConfig) AgentBuilder {
 	if userConfig != nil {
-		// Directly use the user's config without processing through defaults
-		// since the user has already provided their desired configuration values
 		b.config = userConfig
 	}
 	return b

--- a/server/agent_builder_test.go
+++ b/server/agent_builder_test.go
@@ -569,7 +569,6 @@ func TestAgentBuilder_GetConfig(t *testing.T) {
 	}
 }
 
-// TestAgentBuilder_WithConfigPreservesUserValues tests the fix for issue #63
 func TestAgentBuilder_WithConfigPreservesUserValues(t *testing.T) {
 	tests := []struct {
 		name                        string
@@ -578,18 +577,18 @@ func TestAgentBuilder_WithConfigPreservesUserValues(t *testing.T) {
 	}{
 		{
 			name:                        "non_zero_values",
-			maxChatCompletionIterations: 20, // User wants 20, default is 10
+			maxChatCompletionIterations: 20,
 			systemPrompt:                "Custom prompt",
 		},
 		{
 			name:                        "zero_value_for_max_iterations",
-			maxChatCompletionIterations: 0, // User explicitly wants 0, should not be overridden
+			maxChatCompletionIterations: 0,
 			systemPrompt:                "Zero iterations prompt",
 		},
 		{
 			name:                        "empty_system_prompt",
 			maxChatCompletionIterations: 5,
-			systemPrompt:                "", // User explicitly wants empty prompt
+			systemPrompt:                "",
 		},
 	}
 


### PR DESCRIPTION
Fixes #63

The WithConfig method was incorrectly processing user-provided configuration through NewWithDefaults(), which would overwrite user values (especially zero values) with struct tag defaults.

The fix simplifies WithConfig to directly assign user configuration without processing through the defaults system, since users have already provided their desired configuration values.

This resolves the issue where MaxChatCompletionIterations=0 would be overridden to the default value of 10.



Generated with [Claude Code](https://claude.ai/code)